### PR TITLE
【用户注册登录系统】【三方API】 用shadcn-ui card实现可复用Login form components

### DIFF
--- a/nodejs/auth-tutorial/README.md
+++ b/nodejs/auth-tutorial/README.md
@@ -75,6 +75,10 @@ Would you like to customize the default import alias(@/*)? >  No
 
 ## 添加shadcn-ui
 
+> 详见： [shadcn/ui install](https://ui.shadcn.com/docs/installation/next)
+
+All shadcn-ui components are installed in path: `./components/ui`, all files are named as `[component-name].tsx`, and these files are generated automatically.
+
 ```bash
 npm install shadcn-ui@latest init
 ``` 
@@ -88,12 +92,32 @@ npm install shadcn-ui@latest init
 ```
 
 
-## Add shadcn-ui button
+### Add shadcn-ui button
 
 > 详见： [shadcn/ui Button](https://ui.shadcn.com/docs/components/button)
 
+
 ```bash
 npx shadcn@latest add button
+```
+
+### Add shadcn-ui card
+
+> 详见： [shadcn/ui Card](https://ui.shadcn.com/docs/components/card)
+
+```bash
+npx shadcn@latest add card
+```
+
+
+## Social Login
+
+### Social Icon
+
+> Used in socal.tsx, for social media login
+
+```bash
+npm i react-icons
 ```
 
 

--- a/nodejs/auth-tutorial/app/(auth)/layout.tsx
+++ b/nodejs/auth-tutorial/app/(auth)/layout.tsx
@@ -2,15 +2,15 @@ import Link from 'next/link';
 
 const AuthLayout = ({ children }: { children: React.ReactNode }) => {
     return (
-        <div>
-            <nav className='flex justify-start items-center p-4 space-x-4'>
+        <div className="flex h-full flex-col items-center justify-center bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-sky-400 to-blue-800">
+            {/* <nav className='flex justify-start items-center p-4 space-x-4'>
                 <Link href="/login" className="bg-red-500 text-white px-4 py-2 rounded-md hover:bg-red-300 transition-colors duration-200">
                     NavBar: Login
                 </Link>
                 <Link href="/register" className="bg-red-500 text-white px-4 py-2 rounded-md hover:bg-red-300 transition-colors duration-200">
                     NavBar: Register
                 </Link>
-            </nav>
+            </nav> */}
             {children}
         </div>
     );

--- a/nodejs/auth-tutorial/app/(auth)/login/page.tsx
+++ b/nodejs/auth-tutorial/app/(auth)/login/page.tsx
@@ -1,8 +1,8 @@
+import { LoginForm } from '@/components/auth/login-form';
+
 const LoginPage = () => {
     return (
-        <div>
-            Login Page
-        </div>
+        <LoginForm />
     );
 };
 

--- a/nodejs/auth-tutorial/components/auth/back-button.tsx
+++ b/nodejs/auth-tutorial/components/auth/back-button.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+
+interface BackButtonProps {
+    href: string;
+    label: string;
+}
+
+export const BackButton = ({ 
+    href, 
+    label,
+}: BackButtonProps) => {
+    return (
+        <Button
+            variant="link"
+            className="font-normal w-full"
+            size="sm"
+            asChild={true}
+        >
+            <Link href={href}>
+                {label}
+            </Link>
+        </Button>
+    );
+};

--- a/nodejs/auth-tutorial/components/auth/card-wrapper.tsx
+++ b/nodejs/auth-tutorial/components/auth/card-wrapper.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardFooter } from "@/components/ui/card";
+import { Header } from "@/components/auth/header";
+import { Social } from "@/components/auth/social";
+import { BackButton } from "@/components/auth/back-button";
+
+interface CardWrapperProps {
+    children: React.ReactNode;
+    headerLabel: string;
+    backButtonLabel: string;
+    backButtonHref: string;
+    showSocial?: boolean;
+};
+
+export const CardWrapper = ({ 
+    children, 
+    headerLabel, 
+    backButtonLabel, 
+    backButtonHref, 
+    showSocial = false 
+}: CardWrapperProps) => {
+    return (
+        <Card className="w-[400px] shadow-md p-4">
+            <CardHeader>
+                <Header label={headerLabel} />
+            </CardHeader>
+
+            <CardContent>
+                {children}
+            </CardContent>
+
+            {showSocial && (
+                <CardFooter>
+                    <Social />
+                </CardFooter>
+            )}
+
+            <CardFooter>
+                <BackButton 
+                    label={backButtonLabel} 
+                    href={backButtonHref} 
+                />
+            </CardFooter>
+
+        </Card>
+    );
+};

--- a/nodejs/auth-tutorial/components/auth/header.tsx
+++ b/nodejs/auth-tutorial/components/auth/header.tsx
@@ -1,0 +1,30 @@
+import { Poppins } from "next/font/google";
+import { cn } from "@/lib/utils";
+
+const poppins = Poppins({
+    subsets: ["latin"],
+    weight: ["600"],
+});
+
+
+interface HeaderProps {
+    label: string;
+};
+
+export const Header = ({ 
+    label, 
+}: HeaderProps) => {
+    return (
+        <div className="w-full flex flex-col gap-y-4 items-center">
+            <h1 className={cn(
+                "text-3xl font-semibold", 
+                poppins.className,
+            )}>
+              🔐 Auth
+            </h1>
+            <p className="text-muted-foreground text-sm">
+                {label}
+            </p>
+        </div>
+    )
+}

--- a/nodejs/auth-tutorial/components/auth/login-form.tsx
+++ b/nodejs/auth-tutorial/components/auth/login-form.tsx
@@ -1,0 +1,14 @@
+import { CardWrapper } from "@/components/auth/card-wrapper";
+
+export const LoginForm = () => {
+    return (
+        <CardWrapper
+            headerLabel="Welcome back Login"
+            backButtonLabel="Dont have an account?"
+            backButtonHref="/register"
+            showSocial={true}
+        >
+            Login Form
+        </CardWrapper>
+    );
+};

--- a/nodejs/auth-tutorial/components/auth/social.tsx
+++ b/nodejs/auth-tutorial/components/auth/social.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { FcGoogle } from "react-icons/fc"; 
+import { FaGithub } from "react-icons/fa";
+
+import { Button } from "@/components/ui/button";
+
+export const Social = () => {
+    return (
+        <div className="flex items-center w-full gap-x-2">
+            <Button  
+                size="lg"
+                className="w-full"
+                variant="outline"
+                onClick={() => {
+                    alert("google log in");
+                }}
+            >
+                <FcGoogle className="h-5 w-5" />
+            </Button>
+
+            <Button
+                size="lg"
+                className="w-full"
+                variant="outline"
+                onClick={() => {
+                    alert("github log in");
+                }}
+            >
+                <FaGithub className="h-5 w-5" />
+            </Button>
+
+        </div>
+    );
+}   

--- a/nodejs/auth-tutorial/components/ui/card.tsx
+++ b/nodejs/auth-tutorial/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/nodejs/auth-tutorial/package-lock.json
+++ b/nodejs/auth-tutorial/package-lock.json
@@ -16,6 +16,7 @@
         "next": "14.2.13",
         "react": "^18",
         "react-dom": "^18",
+        "react-icons": "^5.3.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -4127,6 +4128,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/nodejs/auth-tutorial/package.json
+++ b/nodejs/auth-tutorial/package.json
@@ -17,6 +17,7 @@
     "next": "14.2.13",
     "react": "^18",
     "react-dom": "^18",
+    "react-icons": "^5.3.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
 shadcn-ui card实现可复用Login form components

## Add shadcn-ui card

> 详见： [shadcn/ui Card](https://ui.shadcn.com/docs/components/card)

```bash
npx shadcn@latest add card
```

## Social Login

### Social Icon

> Used in socal.tsx, for social media login

```bash
npm i react-icons
```

## 增加部分

1. LoginForm 整体框架(`login-form.tsx`)，LoginForm主要内容就是CardWrapper
2. CardWrapper in `card-wrapper.tsx`，包含三个主要部分：CardHeader, CardContent, showSocial (CardFooter), BackButton (CardFooter) 
3. CardHeader in `header.tsx`
4. CardFooter: showSocial in `social.tsx`
5. CardFooter: BackButton in `back-button.tsx`


## 实际效果
![Login form components](https://github.com/user-attachments/assets/68ccdbfe-15e0-4d18-b114-33903d883bf1)
